### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -6,4 +6,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v1
+        uses: canonical/has-signed-canonical-cla@046337b42822b7868ad62970988929c79f9c1d40 # v1


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to full commit SHAs for supply-chain security hardening, replacing mutable tag references.

## Why

Mutable tags (e.g. `@v4`) can be moved by upstream maintainers or by an attacker who compromises an action repo. Pinning to a SHA ensures workflows always run exactly the reviewed code.

This follows GitHub's own security hardening guidance and improves our OpenSSF Scorecard rating.

## Changes

- Pinned all third-party and GitHub-maintained actions in workflow files to full 40-character commit SHAs
- Preserved original tag/branch versions in inline comments for readability
- Left already-pinned actions unchanged

## Testing

- Verified all `uses:` references in `.github/workflows/` now use immutable SHAs